### PR TITLE
Add private_key_hex faker, bump v0.13.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sw-utils"
-version = "v0.13.2"
+version = "v0.13.3"
 description = "StakeWise Python utils"
 authors = ["StakeWise Labs <info@stakewise.io>"]
 license = "GPL-3.0-or-later"

--- a/sw_utils/tests/factories.py
+++ b/sw_utils/tests/factories.py
@@ -21,6 +21,10 @@ class Web3Provider(BaseProvider):
         private_key = G2ProofOfPossession.KeyGen(seed)
         return private_key
 
+    def private_key_hex(self) -> HexStr:
+        # 32-byte private key as 0x-prefixed hex string
+        return Web3.to_hex(random.randbytes(32))
+
     def eth_address(self) -> ChecksumAddress:
         account = w3.eth.account.create()
         return account.address


### PR DESCRIPTION
## Summary
- Add `private_key_hex()` to the test `Web3Provider` faker, returning a random 0x-prefixed 32-byte hex private key
- Bump version to v0.13.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)