### PR TITLE
Disable graph reconnecting session, bump v0.13.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sw-utils"
-version = "v0.13.3"
+version = "v0.13.4"
 description = "StakeWise Python utils"
 authors = ["StakeWise Labs <info@stakewise.io>"]
 license = "GPL-3.0-or-later"

--- a/sw_utils/graph/client.py
+++ b/sw_utils/graph/client.py
@@ -33,7 +33,7 @@ class GraphClient:
         self.session: AsyncClientSession | None = None
 
     async def setup(self) -> None:
-        self.session = await self.gql_client.connect_async(reconnecting=True, retry_execute=False)
+        self.session = await self.gql_client.connect_async(reconnecting=False)
 
     async def disconnect(self) -> None:
         await self.gql_client.close_async()


### PR DESCRIPTION
## Summary

Disable the gql `reconnecting=True` session in `GraphClient`, switching to a plain non-reconnecting `AsyncClientSession`.

`reconnecting=True` provides no benefit for `AIOHTTPTransport` (request/response HTTP — there is no persistent connection to reconnect), and its `close_async()` teardown cancels the background `_connection_loop` task **without awaiting it**. That race orphans the underlying `aiohttp.ClientSession`, producing intermittent **"Unclosed client session"** warnings. Query-level robustness is already provided by `retry_gql_errors` in `run_query`.

With `reconnecting=False`, `close_async()` reduces to `transport.close()` (which drains aiohttp deterministically), so cleanup is deterministic with no orphaned sessions. Same happy-path behavior and same query-level retries.

Also dropped `retry_execute=False` — it is only consumed by `ReconnectingAsyncClientSession` and is a no-op on the non-reconnecting path.

Bumped version to `v0.13.4`.
